### PR TITLE
버그의 둥지 플레이어 사망 후처리

### DIFF
--- a/Assets/Animation/_DungeonPlayerController.controller
+++ b/Assets/Animation/_DungeonPlayerController.controller
@@ -25,28 +25,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &-7626693059230042099
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 0}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 1
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1102 &-5057990648616788252
 AnimatorState:
   serializedVersion: 6
@@ -137,8 +115,7 @@ AnimatorState:
   m_Name: Death
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -7626693059230042099}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Scripts/Dungeon/Attack.cs
+++ b/Assets/Scripts/Dungeon/Attack.cs
@@ -33,7 +33,8 @@ public class Attack : MonoBehaviour
         attackDelay += Time.deltaTime;
         isAttackReady = rate < attackDelay;
 
-        if (Input.GetButtonDown("Fire1") && isAttackReady)
+        var isDead = HatcheryManager.Instance.myPlayer.isDead;
+        if (Input.GetButtonDown("Fire1") && isAttackReady && !isDead)
         {
             StopCoroutine("TryAttack");
             StartCoroutine("TryAttack");

--- a/Assets/Scripts/Dungeon/Character.cs
+++ b/Assets/Scripts/Dungeon/Character.cs
@@ -23,7 +23,7 @@ public class Character : MonoBehaviour
 	private Vector3 lastPos;
 	private float elapsedFromMovePacket;
 
-	private bool isDead = false;
+	public bool isDead = false;
 
 	void Start()
 	{

--- a/Assets/Scripts/Dungeon/HatcheryManager.cs
+++ b/Assets/Scripts/Dungeon/HatcheryManager.cs
@@ -233,7 +233,8 @@ public class HatcheryManager : MonoBehaviour
 				hittedPlayer.DeadMotion();
 				GameObject.Find("UIResult").transform.Find("LosePopup").gameObject.SetActive(true);
 			}
-			hittedPlayer.HitMotion();
+			else
+				hittedPlayer.HitMotion();
 			return;
 		}
 
@@ -242,7 +243,10 @@ public class HatcheryManager : MonoBehaviour
         {
 			int playerIdx = UIPlayerMappings[pkt.PlayerId];
 			uiOtherPlayersInformation[playerIdx].SetCurHP(pkt.PlayerCurHp);
-			hittedPlayer.HitMotion();
+			if (pkt.PlayerCurHp <= 0)
+				hittedPlayer.DeadMotion();
+			else
+				hittedPlayer.HitMotion();
 		}
         else
         {

--- a/Assets/Scripts/Dungeon/ThirdPersonController.cs
+++ b/Assets/Scripts/Dungeon/ThirdPersonController.cs
@@ -22,7 +22,9 @@ public class ThirdPersonController : MonoBehaviour
     void Update()
     {
         LookAround();
-        Move();
+
+        if (!HatcheryManager.Instance.myPlayer.isDead)
+            Move();
     }
 
     private void LookAround()


### PR DESCRIPTION
1. 타 플레이어 사망 모션 출력
2. 플레이어 사망 시 행동 불가하도록 설정
3. 사망 모션 영구 유지 설정